### PR TITLE
Rusoto integration

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,6 +30,10 @@ jobs:
   check:
     runs-on: ubuntu-20.04
     needs: [update]
+    strategy:
+      matrix:
+        tls: [rustls, native]
+        rusoto: [true, false]
     steps:
       - uses: actions/checkout@v2
       - name: Cargo cache
@@ -45,14 +49,21 @@ jobs:
       - name: Check cache
         uses: actions/cache@v2
         with:
-          key: check-${{ hashFiles('Cargo.lock') }}
+          key: check-${{ matrix.tls }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Check
-        run: cargo check --all-targets
+        run: |
+          cargo check --all-targets --no-default-features \
+            --features ${{ matrix.tls == 'rustls' && 'rustls' || 'native-tls' }} \
+            ${{ matrix.rusoto && '--features rusoto' || '' }}
 
   clippy:
     runs-on: ubuntu-20.04
     needs: [check]
+    strategy:
+      matrix:
+        tls: [rustls, native]
+        rusoto: [true, false]
     steps:
       - uses: actions/checkout@v2
       - name: Cargo cache
@@ -68,14 +79,21 @@ jobs:
       - name: Check cache
         uses: actions/cache@v2
         with:
-          key: check-${{ hashFiles('Cargo.lock') }}
+          key: check-${{ matrix.tls }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Clippy
-        run: cargo clippy --all-targets
+        run: |
+          cargo clippy --all-targets --no-default-features \
+            --features ${{ matrix.tls == 'rustls' && 'rustls' || 'native-tls' }} \
+            ${{ matrix.rusoto && '--features rusoto' || '' }}
 
   doc-check:
     runs-on: ubuntu-20.04
     needs: [check]
+    strategy:
+      matrix:
+        tls: [rustls, native]
+        rusoto: [true, false]
     steps:
       - uses: actions/checkout@v2
       - name: Cargo cache
@@ -91,14 +109,21 @@ jobs:
       - name: Check cache
         uses: actions/cache@v2
         with:
-          key: check-${{ hashFiles('Cargo.lock') }}
+          key: check-${{ matrix.tls }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Doc check
-        run: cargo doc --no-deps
+        run: |
+          cargo doc --no-deps --no-default-features \
+            --features ${{ matrix.tls == 'rustls' && 'rustls' || 'native-tls' }} \
+            ${{ matrix.rusoto && '--features rusoto' || '' }}
 
   test:
     runs-on: ubuntu-20.04
     needs: [update]
+    strategy:
+      matrix:
+        tls: [rustls, native]
+        rusoto: [true, false]
     steps:
       - uses: actions/checkout@v2
       - name: Cargo cache
@@ -114,7 +139,18 @@ jobs:
       - name: Test cache
         uses: actions/cache@v2
         with:
-          key: test-${{ hashFiles('Cargo.lock') }}
+          key: test-${{ matrix.tls }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Test
-        run: cargo test
+        run: |
+          cargo test --no-default-features \
+            --features ${{ matrix.tls == 'rustls' && 'rustls' || 'native-tls' }} \
+            ${{ matrix.rusoto && '--features rusoto' || '' }}
+
+  status:
+    runs-on: ubuntu-20.04
+    needs: [clippy, doc-check, test]
+    if: always()
+    steps:
+      - run: exit 1
+        if: needs.clippy.result != 'success' || needs.doc-check.result != 'success' || needs.test.result != 'success'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,12 +32,14 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 name = "aws_sso_flow"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "const-str",
  "dirs-next",
  "futures",
  "md-5 0.10.4",
  "rusoto_core",
+ "rusoto_credential",
  "rusoto_sso",
  "rusoto_sso_oidc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ default = ["rustls"]
 native-tls = ["rusoto_core/native-tls", "rusoto_sso/native-tls", "rusoto_sso_oidc/native-tls"]
 rustls = ["rusoto_core/rustls", "rusoto_sso/rustls", "rusoto_sso_oidc/rustls"]
 
+# Include integration with rusoto_credential
+rusoto = ["async-trait", "rusoto_credential"]
+
 [dependencies]
 chrono = { version = "0.4.22", default-features = false }
 const-str = "0.4.3"
@@ -25,6 +28,13 @@ serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
 tokio = { version = "1.21.0", features = ["fs", "io-util", "sync"] }
 url = "2.3.1"
+
+async-trait = { version = "0.1.57", optional = true }
+# The version constraint is the lowest with a compatible ProvideAwsCredentials trait. There's no
+# upper bound so that the version will adapt to whatever clients are using. There will be breakage
+# if the trait changes in future, but that hopefully won't happen as often as new versions are
+# released with additional service coverage etc.
+rusoto_credential = { version = ">=0.43.0", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.21.0", features = ["macros", "rt-multi-thread"] }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -45,6 +45,7 @@ use crate::{ProfileSource, Region, SsoFlow, VerificationPrompt, CLIENT_NAME};
 /// # Ok(())
 /// # }
 /// ```
+#[derive(Clone)]
 #[allow(clippy::module_name_repetitions)]
 pub struct SsoFlowBuilder<S = ProfileSource, V = Infallible> {
     cache_dir: Option<PathBuf>,

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -48,14 +48,3 @@ impl From<sso::GetRoleCredentialsResponse> for SessionCredentials {
         }
     }
 }
-
-impl From<SessionCredentials> for rusoto_core::credential::AwsCredentials {
-    fn from(creds: SessionCredentials) -> Self {
-        Self::new(
-            creds.access_key_id,
-            creds.secret_access_key,
-            Some(creds.session_token),
-            Some(creds.expires_at),
-        )
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@ mod credentials;
 mod flow;
 mod profile;
 mod region;
+#[cfg(feature = "rusoto")]
+mod rusoto;
 mod sso;
 mod sso_oidc;
 
@@ -33,6 +35,9 @@ pub use crate::{
     profile::{ProfileSource, SsoProfileError},
     region::Region,
 };
+
+#[cfg(feature = "rusoto")]
+pub use crate::rusoto::ChainProvider;
 
 const _: () = assert!(
     const_str::equal!(env!("CARGO_PKG_VERSION_MAJOR"), "0"),

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -45,7 +45,7 @@ const AWS_PROFILE_DEFAULT: &str = "default";
 /// # Ok(()) }
 /// ```
 #[allow(clippy::module_name_repetitions)]
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct ProfileSource {
     config_file: Option<PathBuf>,
     profile: Option<String>,

--- a/src/rusoto.rs
+++ b/src/rusoto.rs
@@ -1,0 +1,133 @@
+use std::fmt;
+
+use async_trait::async_trait;
+use rusoto_credential::{AwsCredentials, CredentialsError, ProvideAwsCredentials};
+
+use crate::{
+    SessionCredentials, SsoConfigSource, SsoFlow, SsoFlowBuilder, SsoProfileError,
+    VerificationPrompt,
+};
+
+#[async_trait]
+impl<S, V> ProvideAwsCredentials for SsoFlowBuilder<S, V>
+where
+    S: SsoConfigSource + Clone + Send + Sync,
+    S::Future: Send,
+    S::Error: Into<SsoProfileError>,
+    V: VerificationPrompt + Clone + Send + Sync,
+{
+    async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
+        self.clone()
+            .build()
+            .await
+            .map_err(CredentialsError::new)?
+            .authenticate()
+            .await
+            .map(Into::into)
+            .map_err(CredentialsError::new)
+    }
+}
+
+#[async_trait]
+impl<V: VerificationPrompt> ProvideAwsCredentials for SsoFlow<V> {
+    async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
+        self.authenticate()
+            .await
+            .map(Into::into)
+            .map_err(CredentialsError::new)
+    }
+}
+
+impl From<SessionCredentials> for AwsCredentials {
+    fn from(credentials: SessionCredentials) -> Self {
+        Self::new(
+            credentials.access_key_id,
+            credentials.secret_access_key,
+            Some(credentials.session_token),
+            Some(credentials.expires_at),
+        )
+    }
+}
+
+/// A generalised version of [`rusoto_credential::ChainProvider`] that provides AWS credentials from
+/// multiple arbitrary sources.
+///
+/// # Example
+///
+/// To exhaust the default rusoto `ChainProvider` before falling back to SSO credentials you could
+/// use:
+///
+/// ```no_run
+/// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::convert::Infallible;
+///
+/// use aws_sso_flow::{ChainProvider, SsoFlow};
+/// use rusoto_credential::ProvideAwsCredentials;
+///
+/// let mut provider = ChainProvider::new()
+///     .push(rusoto_credential::ChainProvider::new())
+///     .push(SsoFlow::builder().verification_prompt(|url| async move {
+///         println!("Go to {url} to sign in");
+///         Ok::<_, Infallible>(())
+///     }));
+///
+/// let credentials = provider.credentials().await?;
+/// # Ok(()) }
+/// ```
+#[derive(Default)]
+pub struct ChainProvider {
+    providers: Vec<Box<dyn ProvideAwsCredentials + Send + Sync>>,
+}
+
+impl ChainProvider {
+    /// Construct a new (empty) `ChainProvider`.
+    ///
+    /// Trying to fetch credentials from an empty provider will always fail. Providers can be added
+    /// with [`push`](Self::push).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a credentials provider to the chain.
+    ///
+    /// The new provider will be invoked if all the previously `push`ed providers fail.
+    #[must_use]
+    pub fn push<P>(mut self, provider: P) -> Self
+    where
+        P: ProvideAwsCredentials + Send + Sync + 'static,
+    {
+        self.providers.push(Box::new(provider));
+        self
+    }
+}
+
+impl fmt::Debug for ChainProvider {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ChainProvider")
+            .field(
+                "providers",
+                &format_args!("[<{} entries>]", self.providers.len()),
+            )
+            .finish()
+    }
+}
+
+#[async_trait]
+impl ProvideAwsCredentials for ChainProvider {
+    async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
+        let mut errors = vec![];
+        for provider in &self.providers {
+            match provider.credentials().await {
+                Ok(credentials) => return Ok(credentials),
+                Err(error) => errors.push(error),
+            }
+        }
+
+        let error_messages: Vec<_> = errors.iter().map(|error| format!("- {}", error)).collect();
+        Err(CredentialsError::new(format!(
+            "Couldn't find AWS credentials through any configured provider; all errors:\n\n{}",
+            error_messages.join("\n")
+        )))
+    }
+}


### PR DESCRIPTION
- 49b7e9e **fix!: remove accidental integration with rusoto**

  This sneaky `From` impl was missed.
  
  BREAKING CHANGE: `SessionCredentials` no longer implements
  `From<rusoto_credential@0.48.0::AwsCredentials>`.

- 6d17683 **feat: add a feature for `rusoto` integration**

  When the `rusoto` feature is enabled, some additional trait
  implementations and utilities will be included:
  
  - Implementations of `ProvideAwsCredentials` for `SsoFlow` and
    `SsoFlowBuilder`.
  - Implementation of `From<SessionCredentials>` for `AwsCredentials`.
  - A `ChainProvider` struct, implementing `ProvideAwsCredentials` by
    falling through a list of providers.
  
  The CI pipeline has been upgraded to run checks against all reasonable
  feature combinations (`rustls` or `native-tls`, with and without
  `rusoto`). Since each matrix item creates its own check, a single
  `status` job has been added to aggregate any failures from the matrix
  checks. This can then be used as a required status check, so that they
  don't have to be changed whenever the matrix changes.
