### PR TITLE
Use aws-sdk instead of rusoto

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,6 +34,7 @@ jobs:
       matrix:
         tls: [rustls, native]
         rusoto: [true, false]
+        aws-sdk: [true, false]
     steps:
       - uses: actions/checkout@v2
       - name: Cargo cache
@@ -49,12 +50,13 @@ jobs:
       - name: Check cache
         uses: actions/cache@v2
         with:
-          key: check-${{ matrix.tls }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
+          key: check-${{ matrix.tls }}-${{ matrix.aws-sdk }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Check
         run: |
           cargo check --all-targets --no-default-features \
             --features ${{ matrix.tls == 'rustls' && 'rustls' || 'native-tls' }} \
+            ${{ matrix.aws-sdk && '--features aws-sdk' || '' }} \
             ${{ matrix.rusoto && '--features rusoto' || '' }}
 
   clippy:
@@ -79,12 +81,13 @@ jobs:
       - name: Check cache
         uses: actions/cache@v2
         with:
-          key: check-${{ matrix.tls }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
+          key: check-${{ matrix.tls }}-${{ matrix.aws-sdk }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Clippy
         run: |
           cargo clippy --all-targets --no-default-features \
             --features ${{ matrix.tls == 'rustls' && 'rustls' || 'native-tls' }} \
+            ${{ matrix.aws-sdk && '--features aws-sdk' || '' }} \
             ${{ matrix.rusoto && '--features rusoto' || '' }}
 
   doc-check:
@@ -109,12 +112,13 @@ jobs:
       - name: Check cache
         uses: actions/cache@v2
         with:
-          key: check-${{ matrix.tls }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
+          key: check-${{ matrix.tls }}-${{ matrix.aws-sdk }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Doc check
         run: |
           cargo doc --no-deps --no-default-features \
             --features ${{ matrix.tls == 'rustls' && 'rustls' || 'native-tls' }} \
+            ${{ matrix.aws-sdk && '--features aws-sdk' || '' }} \
             ${{ matrix.rusoto && '--features rusoto' || '' }}
 
   test:
@@ -139,12 +143,13 @@ jobs:
       - name: Test cache
         uses: actions/cache@v2
         with:
-          key: test-${{ matrix.tls }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
+          key: test-${{ matrix.tls }}-${{ matrix.aws-sdk }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Test
         run: |
           cargo test --no-default-features \
             --features ${{ matrix.tls == 'rustls' && 'rustls' || 'native-tls' }} \
+            ${{ matrix.aws-sdk && '--features aws-sdk' || '' }} \
             ${{ matrix.rusoto && '--features rusoto' || '' }}
 
   status:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ required-features = ["aws-sdk"]
 
 [features]
 default = ["rustls"]
-native-tls = ["rusoto_core/native-tls", "rusoto_sso/native-tls", "rusoto_sso_oidc/native-tls"]
-rustls = ["rusoto_core/rustls", "rusoto_sso/rustls", "rusoto_sso_oidc/rustls"]
+native-tls = ["aws-config/native-tls", "aws-sdk-sso/native-tls", "aws-sdk-ssooidc/native-tls"]
+rustls = ["aws-config/rustls", "aws-sdk-sso/rustls", "aws-sdk-ssooidc/rustls"]
 
 # Include integration with aws-sdk
 aws-sdk = ["dep:aws-types-integration"]
@@ -23,14 +23,14 @@ aws-sdk = ["dep:aws-types-integration"]
 rusoto = ["async-trait", "rusoto_credential"]
 
 [dependencies]
-chrono = { version = "0.4.22", default-features = false }
+aws-config = { version = "0.49.0", default-features = false, features = ["client-hyper", "rt-tokio"] }
+aws-sdk-sso = { version = "0.19.0", default-features = false, features = ["rt-tokio"] }
+aws-sdk-ssooidc = { version = "0.19.0", default-features = false, features = ["rt-tokio"] }
+chrono = { version = "0.4.22", default-features = false, features = ["clock", "serde"] }
 const-str = "0.4.3"
 dirs-next = "2.0.0"
 futures = "0.3.24"
 md-5 = "0.10.4"
-rusoto_core = { version = "0.48.0", default-features = false }
-rusoto_sso = { version = "0.48.0", default-features = false }
-rusoto_sso_oidc = { version = "0.48.0", default-features = false }
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
 tokio = { version = "1.21.0", features = ["fs", "io-util", "sync"] }
@@ -50,5 +50,4 @@ rusoto_credential = { version = ">=0.43.0", optional = true }
 aws-types-integration = { package = "aws-types", version = ">=0.31.0", optional = true }
 
 [dev-dependencies]
-aws-config = "0.49.0"
 tokio = { version = "1.21.0", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,4 +50,5 @@ rusoto_credential = { version = ">=0.43.0", optional = true }
 aws-types-integration = { package = "aws-types", version = ">=0.31.0", optional = true }
 
 [dev-dependencies]
+aws-types-integration = { package = "aws-types", version = "=0.49.0" }
 tokio = { version = "1.21.0", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,6 @@ async-trait = { version = "0.1.57", optional = true }
 rusoto_credential = { version = ">=0.43.0", optional = true }
 
 [dev-dependencies]
+aws-config = "0.49.0"
+aws-types = "0.49.0"
 tokio = { version = "1.21.0", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_sso_flow"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Chris Connelly <chris@connec.co.uk>"]
 license = "MIT"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,17 @@ edition = "2021"
 description = "AWS SSO authentication flow"
 repository = "https://github.com/connec/aws_sso_flow"
 
+[[example]]
+name = "aws_sdk"
+required-features = ["aws-sdk"]
+
 [features]
 default = ["rustls"]
 native-tls = ["rusoto_core/native-tls", "rusoto_sso/native-tls", "rusoto_sso_oidc/native-tls"]
 rustls = ["rusoto_core/rustls", "rusoto_sso/rustls", "rusoto_sso_oidc/rustls"]
+
+# Include integration with aws-sdk
+aws-sdk = ["dep:aws-types-integration"]
 
 # Include integration with rusoto_credential
 rusoto = ["async-trait", "rusoto_credential"]
@@ -31,12 +38,17 @@ url = "2.3.1"
 
 async-trait = { version = "0.1.57", optional = true }
 # The version constraint is the lowest with a compatible ProvideAwsCredentials trait. There's no
-# upper bound so that the version will adapt to whatever clients are using. There will be breakage
+# upper bound so that the version can adapt to whatever clients are using. There will be breakage if
 # if the trait changes in future, but that hopefully won't happen as often as new versions are
 # released with additional service coverage etc.
 rusoto_credential = { version = ">=0.43.0", optional = true }
 
+# The version constraint is the lowest with a compatible ProvideCredentials trait. There's no upper
+# bound so that the version can adapt to whatever clients are using. There will be breakage if the
+# trait changes in future, but that hopefully won't happen as often as new versions are released
+# with additional service coverage etc.
+aws-types-integration = { package = "aws-types", version = ">=0.31.0", optional = true }
+
 [dev-dependencies]
 aws-config = "0.49.0"
-aws-types = "0.49.0"
 tokio = { version = "1.21.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/aws_sdk.rs
+++ b/examples/aws_sdk.rs
@@ -1,11 +1,9 @@
-use std::{convert::Infallible, fmt};
+use std::convert::Infallible;
 
 use aws_config::meta::credentials::CredentialsProviderChain;
-use aws_sso_flow::{SsoConfigSource, SsoFlow, SsoFlowBuilder, VerificationPrompt};
-use aws_types::{
-    credentials::{CredentialsError, ProvideCredentials},
-    Credentials,
-};
+use aws_types_integration::credentials::ProvideCredentials;
+
+use aws_sso_flow::SsoFlow;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -13,7 +11,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("Go to {url} to sign in with SSO");
         Ok::<_, Infallible>(())
     });
-    let provider = CredentialsProviderChain::first_try("SsoFlow", SsoFlowProvider(flow))
+    let provider = CredentialsProviderChain::first_try("SsoFlow", flow)
         .or_default_provider()
         .await;
 
@@ -22,46 +20,4 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dbg!(credentials);
 
     Ok(())
-}
-
-struct SsoFlowProvider<S, V>(SsoFlowBuilder<S, V>);
-
-impl<S, V> fmt::Debug for SsoFlowProvider<S, V> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SsoFlowProvider").finish_non_exhaustive()
-    }
-}
-
-impl<S, V> ProvideCredentials for SsoFlowProvider<S, V>
-where
-    S: SsoConfigSource + Clone + Send + Sync,
-    S::Future: Send,
-    V: VerificationPrompt + Send + Sync,
-{
-    fn provide_credentials<'a>(&'a self) -> aws_types::credentials::future::ProvideCredentials<'a>
-    where
-        Self: 'a,
-    {
-        aws_types::credentials::future::ProvideCredentials::new(async move {
-            let flow = self
-                .0
-                .clone()
-                .build()
-                .await
-                .map_err(CredentialsError::not_loaded)?;
-
-            flow.authenticate()
-                .await
-                .map(|creds| {
-                    Credentials::new(
-                        creds.access_key_id,
-                        creds.secret_access_key,
-                        Some(creds.session_token),
-                        Some(creds.expires_at.into()),
-                        "SsoFlow",
-                    )
-                })
-                .map_err(CredentialsError::provider_error)
-        })
-    }
 }

--- a/examples/aws_sdk.rs
+++ b/examples/aws_sdk.rs
@@ -1,0 +1,67 @@
+use std::{convert::Infallible, fmt};
+
+use aws_config::meta::credentials::CredentialsProviderChain;
+use aws_sso_flow::{SsoConfigSource, SsoFlow, SsoFlowBuilder, VerificationPrompt};
+use aws_types::{
+    credentials::{CredentialsError, ProvideCredentials},
+    Credentials,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let flow = SsoFlow::builder().verification_prompt(|url| async move {
+        println!("Go to {url} to sign in with SSO");
+        Ok::<_, Infallible>(())
+    });
+    let provider = CredentialsProviderChain::first_try("SsoFlow", SsoFlowProvider(flow))
+        .or_default_provider()
+        .await;
+
+    let credentials = provider.provide_credentials().await?;
+
+    dbg!(credentials);
+
+    Ok(())
+}
+
+struct SsoFlowProvider<S, V>(SsoFlowBuilder<S, V>);
+
+impl<S, V> fmt::Debug for SsoFlowProvider<S, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SsoFlowProvider").finish_non_exhaustive()
+    }
+}
+
+impl<S, V> ProvideCredentials for SsoFlowProvider<S, V>
+where
+    S: SsoConfigSource + Clone + Send + Sync,
+    S::Future: Send,
+    V: VerificationPrompt + Send + Sync,
+{
+    fn provide_credentials<'a>(&'a self) -> aws_types::credentials::future::ProvideCredentials<'a>
+    where
+        Self: 'a,
+    {
+        aws_types::credentials::future::ProvideCredentials::new(async move {
+            let flow = self
+                .0
+                .clone()
+                .build()
+                .await
+                .map_err(CredentialsError::not_loaded)?;
+
+            flow.authenticate()
+                .await
+                .map(|creds| {
+                    Credentials::new(
+                        creds.access_key_id,
+                        creds.secret_access_key,
+                        Some(creds.session_token),
+                        Some(creds.expires_at.into()),
+                        "SsoFlow",
+                    )
+                })
+                .map_err(CredentialsError::provider_error)
+        })
+    }
+}

--- a/src/aws_sdk.rs
+++ b/src/aws_sdk.rs
@@ -28,7 +28,7 @@ use crate::{SessionCredentials, SsoConfigSource, SsoFlow, SsoFlowBuilder, Verifi
 ///
 /// use aws_config::meta::credentials::CredentialsProviderChain;
 /// use aws_types::credentials::ProvideCredentials;
-/// use aws_sso_flow::{SsoConfig, SsoFlow};
+/// use aws_sso_flow::{Region, SsoConfig, SsoFlow};
 ///
 /// // Configure an SSO flow that loads SSO from shared config and prints the verification URL
 /// let flow = SsoFlow::builder().verification_prompt(|url| async move {
@@ -48,7 +48,7 @@ use crate::{SessionCredentials, SsoConfigSource, SsoFlow, SsoFlowBuilder, Verifi
 /// // Configure an SSO flow that uses static configuration
 /// let flow = SsoFlow::builder()
 ///     .config(SsoConfig {
-///         region: "eu-west-1".parse().unwrap(),
+///         region: Region::new("eu-west-1"),
 ///         start_url: "myorg.signin.amazonaws.com/start".to_string(),
 ///         account_id: "012345678910".to_string(),
 ///         role_name: "developer".to_string(),

--- a/src/aws_sdk.rs
+++ b/src/aws_sdk.rs
@@ -1,0 +1,131 @@
+use std::fmt;
+
+use aws_types_integration::{
+    credentials::{
+        future::ProvideCredentials as ProvideCredentialsFut, CredentialsError, ProvideCredentials,
+    },
+    Credentials,
+};
+
+use crate::{SessionCredentials, SsoConfigSource, SsoFlow, SsoFlowBuilder, VerificationPrompt};
+
+/// Provide credentials via an [`SsoFlowBuilder`].
+///
+/// If SSO configuration can't be loaded for any reason, errors are converted to
+/// [`CredentialsError::CredentialsNotLoaded`], which won't stop resolution if the builder is used
+/// as part of a credentials chain. If an SSO profile is loaded successfully, then any subsequent
+/// authentication errors are converted to [`CredentialsError::ProviderError`] which will stop
+/// resolution.
+///
+/// The aws-sdk's SSO credentials provider behaves similarly but relies on a fresh SSO OIDC access
+/// token being cached (at at `~/.aws/sso/cache/{sha1(start_url)}.json`). As such, `SsoFlowBuilder`s
+/// should be set to run *before* the default provider chain.
+///
+/// ```no_run
+/// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # use aws_types_integration as aws_types;
+/// use std::convert::Infallible;
+///
+/// use aws_config::meta::credentials::CredentialsProviderChain;
+/// use aws_types::credentials::ProvideCredentials;
+/// use aws_sso_flow::{SsoConfig, SsoFlow};
+///
+/// // Configure an SSO flow that loads SSO from shared config and prints the verification URL
+/// let flow = SsoFlow::builder().verification_prompt(|url| async move {
+///     println!("Go to {url} to sign in with SSO");
+///     Ok::<_, Infallible>(())
+/// });
+///
+/// // Try the SSO flow *first*, and fall back to the default provider chain
+/// let provider = CredentialsProviderChain::first_try("SsoFlow", flow)
+///     .or_default_provider()
+///     .await;
+///
+/// // `flow` will be attempted first, falling back to the default chain if SSO configuration can't
+/// // be loaded.
+/// let creds = provider.provide_credentials().await?;
+///
+/// // Configure an SSO flow that uses static configuration
+/// let flow = SsoFlow::builder()
+///     .config(SsoConfig {
+///         region: "eu-west-1".parse().unwrap(),
+///         start_url: "myorg.signin.amazonaws.com/start".to_string(),
+///         account_id: "012345678910".to_string(),
+///         role_name: "developer".to_string(),
+///     })
+///     .verification_prompt(|url| async move {
+///         println!("Go to {url} to sign in with SSO");
+///         Ok::<_, Infallible>(())
+///     });
+///
+/// // Try the default chain, and fall back to the statically configured SSO flow
+/// let provider = CredentialsProviderChain::default_provider()
+///     .await
+///     .or_else("SsoFlow", flow);
+///
+/// // the default chain will be attempted first, falling back to `flow` only if no default
+/// // providers could be loaded.
+/// let creds = provider.provide_credentials().await?;
+/// # Ok(()) }
+/// ```
+impl<S, V> ProvideCredentials for SsoFlowBuilder<S, V>
+where
+    S: SsoConfigSource + Clone + fmt::Debug + Send + Sync,
+    S::Future: Send,
+    V: VerificationPrompt + Clone + Send + Sync,
+{
+    fn provide_credentials<'a>(&'a self) -> ProvideCredentialsFut<'a>
+    where
+        Self: 'a,
+    {
+        ProvideCredentialsFut::new(async {
+            let flow = self
+                .clone()
+                .build()
+                .await
+                .map_err(CredentialsError::not_loaded)?;
+
+            let creds = flow
+                .authenticate()
+                .await
+                .map(Into::into)
+                .map_err(CredentialsError::provider_error)?;
+
+            Ok(creds)
+        })
+    }
+}
+
+impl<V> ProvideCredentials for SsoFlow<V>
+where
+    V: VerificationPrompt + Send + Sync,
+{
+    fn provide_credentials<'a>(
+        &'a self,
+    ) -> aws_types_integration::credentials::future::ProvideCredentials<'a>
+    where
+        Self: 'a,
+    {
+        ProvideCredentialsFut::new(async {
+            let creds = self
+                .authenticate()
+                .await
+                .map(Into::into)
+                .map_err(CredentialsError::provider_error)?;
+
+            Ok(creds)
+        })
+    }
+}
+
+impl From<SessionCredentials> for Credentials {
+    fn from(creds: SessionCredentials) -> Self {
+        Credentials::new(
+            creds.access_key_id,
+            creds.secret_access_key,
+            Some(creds.session_token),
+            Some(creds.expires_at.into()),
+            "SsoFlow",
+        )
+    }
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -12,14 +12,14 @@ use crate::{ProfileSource, Region, SsoFlow, VerificationPrompt, CLIENT_NAME};
 /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// use std::{convert::Infallible, fmt};
 ///
-/// use aws_sso_flow::{SsoConfig, SsoFlowBuilder};
+/// use aws_sso_flow::{Region, SsoConfig, SsoFlowBuilder};
 ///
 /// let flow = SsoFlowBuilder::new()
 ///     // change the cache directory to "$PWD/.cache" instead of OS cache dir
 ///     .cache_dir(".cache")
 ///     // use hard-coded SSO configuration instead of loading from profile
 ///     .config(SsoConfig {
-///         region: "eu-west-1".parse().unwrap(),
+///         region: Region::new("eu-west-1"),
 ///         start_url: "myorg.awsapps.com/start".to_string(),
 ///         account_id: "012345678910".to_string(),
 ///         role_name: "PowerUser".to_string(),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -211,11 +211,11 @@ pub struct SsoConfig {
 }
 
 impl SsoConfigSource for SsoConfig {
-    type Future = futures::future::Ready<Result<Self, Self::Error>>;
+    type Future = std::future::Ready<Result<Self, Self::Error>>;
 
     type Error = Infallible;
 
     fn load(self) -> Self::Future {
-        futures::future::ready(Ok(self))
+        std::future::ready(Ok(self))
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,4 @@
-use std::{convert::Infallible, path::PathBuf};
+use std::{convert::Infallible, fmt, path::PathBuf};
 
 use crate::{ProfileSource, Region, SsoFlow, VerificationPrompt, CLIENT_NAME};
 
@@ -68,6 +68,23 @@ impl Default for SsoFlowBuilder<ProfileSource, Infallible> {
             config_source: ProfileSource::default(),
             verification_prompt: None,
         }
+    }
+}
+
+impl<S: fmt::Debug, V> fmt::Debug for SsoFlowBuilder<S, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SsoFlowBuilder")
+            .field("cache_dir", &self.cache_dir)
+            .field("config_source", &self.config_source)
+            .field(
+                "verification_prompt",
+                if self.verification_prompt.is_some() {
+                    &"Some(_)"
+                } else {
+                    &"None"
+                },
+            )
+            .finish()
     }
 }
 
@@ -174,7 +191,7 @@ pub trait SsoConfigSource {
 }
 
 /// AWS SSO configuration.
-#[derive(Hash)]
+#[derive(Clone, Debug, Hash)]
 pub struct SsoConfig {
     /// The AWS region in which SSO was setup.
     ///

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -12,6 +12,7 @@ use tokio::fs;
 
 const CACHE_BUFFER: std::time::Duration = std::time::Duration::from_secs(60);
 
+#[derive(Debug)]
 pub(crate) struct Cache {
     dir: Option<PathBuf>,
     suffix: String,

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -1,5 +1,6 @@
 use std::{convert::Infallible, fmt, path::PathBuf};
 
+use aws_config::SdkConfig;
 use url::Url;
 
 use crate::{
@@ -80,14 +81,12 @@ where
         config: SsoConfig,
         verification_prompt: V,
     ) -> Self {
-        let client = std::sync::Arc::new(
-            rusoto_core::HttpClient::new().expect("HttpClient::new never panics"),
-        );
+        let sdk_config = SdkConfig::builder().region(config.region.0.clone()).build();
 
         Self {
             cache: Cache::new(cache_dir, &config),
-            sso_oidc_client: sso_oidc::Client::new(client.clone(), config.region.clone()),
-            sso_client: sso::Client::new(client, config.region.clone()),
+            sso_oidc_client: sso_oidc::Client::new(&sdk_config),
+            sso_client: sso::Client::new(&sdk_config),
             config,
             verification_prompt,
         }

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -159,6 +159,18 @@ where
     }
 }
 
+impl<V> fmt::Debug for SsoFlow<V> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("SsoFlow")
+            .field("cache", &self.cache)
+            .field("sso_oidc_client", &self.sso_oidc_client)
+            .field("sso_client", &self.sso_client)
+            .field("config", &self.config)
+            .field("verification_prompt", &"_")
+            .finish()
+    }
+}
+
 /// An SSO verification prompt.
 ///
 /// The AWS SSO authentication flow requires users to explicitly grant access by visiting a URL and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@
 //! # Ok(()) }
 //! ```
 
+#[cfg(feature = "aws-sdk")]
+mod aws_sdk;
 mod builder;
 mod cache;
 mod credentials;

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -45,7 +45,7 @@ const AWS_PROFILE_DEFAULT: &str = "default";
 /// # Ok(()) }
 /// ```
 #[allow(clippy::module_name_repetitions)]
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ProfileSource {
     config_file: Option<PathBuf>,
     profile: Option<String>,

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -205,22 +205,12 @@ async fn parse_profile(path: &Path, profile: &str) -> Result<SsoConfig, SsoProfi
     }
 
     match (region, start_url, account_id, role_name) {
-        (Some(region), Some(start_url), Some(account_id), Some(role_name)) => {
-            let region = region.parse().map_err(|error| {
-                SsoProfileError::new(format!(
-                    "error in profile {} in config file {}: {}",
-                    profile,
-                    path.display(),
-                    error
-                ))
-            })?;
-            Ok(SsoConfig {
-                region,
-                start_url,
-                account_id,
-                role_name,
-            })
-        }
+        (Some(region), Some(start_url), Some(account_id), Some(role_name)) => Ok(SsoConfig {
+            region: crate::Region::new(region),
+            start_url,
+            account_id,
+            role_name,
+        }),
         (region, start_url, account_id, role_name) => {
             let missing: Vec<_> = region
                 .map_or_else(|| Some("sso_region"), |_| None)

--- a/src/rusoto.rs
+++ b/src/rusoto.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use rusoto_credential::{AwsCredentials, CredentialsError, ProvideAwsCredentials};
 
 use crate::{
-    SessionCredentials, SsoConfigSource, SsoFlow, SsoFlowBuilder, SsoProfileError,
+    SessionCredentials, SsoConfigSource, SsoFlow, SsoFlowBuilder,
     VerificationPrompt,
 };
 
@@ -13,7 +13,6 @@ impl<S, V> ProvideAwsCredentials for SsoFlowBuilder<S, V>
 where
     S: SsoConfigSource + Clone + Send + Sync,
     S::Future: Send,
-    S::Error: Into<SsoProfileError>,
     V: VerificationPrompt + Clone + Send + Sync,
 {
     async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {

--- a/src/sso.rs
+++ b/src/sso.rs
@@ -1,5 +1,7 @@
 //! Cleaned up AWS SSO API.
 
+use std::fmt;
+
 use chrono::{DateTime, TimeZone, Utc};
 use rusoto_core::{credential::StaticProvider, DispatchSignedRequest};
 use rusoto_sso::{Sso, SsoClient};
@@ -30,6 +32,12 @@ impl Client {
             .await
             .map_err(|error| error.to_string())
             .and_then(TryInto::try_into)
+    }
+}
+
+impl fmt::Debug for Client {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Client").finish_non_exhaustive()
     }
 }
 

--- a/src/sso_oidc.rs
+++ b/src/sso_oidc.rs
@@ -1,5 +1,7 @@
 //! Cleaned up AWS SSO OIDC API.
 
+use std::fmt;
+
 use chrono::{DateTime, TimeZone, Utc};
 use rusoto_core::{credential::StaticProvider, DispatchSignedRequest, RusotoError};
 use rusoto_sso_oidc::{SsoOidc, SsoOidcClient};
@@ -78,6 +80,12 @@ impl Client {
                 Err(error) => return Err(CreateTokenError::Api(error.to_string())),
             }
         }
+    }
+}
+
+impl fmt::Debug for Client {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Client").finish_non_exhaustive()
     }
 }
 

--- a/src/sso_oidc.rs
+++ b/src/sso_oidc.rs
@@ -2,25 +2,20 @@
 
 use std::fmt;
 
+use aws_config::SdkConfig;
 use chrono::{DateTime, TimeZone, Utc};
-use rusoto_core::{credential::StaticProvider, DispatchSignedRequest, RusotoError};
-use rusoto_sso_oidc::{SsoOidc, SsoOidcClient};
 use url::Url;
 
-use crate::{cache, Region, VerificationPrompt};
+use crate::{cache, VerificationPrompt};
 
 pub(crate) struct Client {
-    inner: SsoOidcClient,
+    inner: aws_sdk_ssooidc::Client,
 }
 
 impl Client {
-    pub(crate) fn new<D>(request_dispatcher: D, region: Region) -> Self
-    where
-        D: DispatchSignedRequest + Send + Sync + 'static,
-    {
-        let anonymous = StaticProvider::new_minimal("".to_string(), "".to_string());
+    pub(crate) fn new(config: &SdkConfig) -> Self {
         Self {
-            inner: SsoOidcClient::new_with(request_dispatcher, anonymous, region.0),
+            inner: aws_sdk_ssooidc::Client::new(config),
         }
     }
 
@@ -29,7 +24,10 @@ impl Client {
         request: RegisterClientRequest,
     ) -> Result<RegisterClientResponse, String> {
         self.inner
-            .register_client(request.into())
+            .register_client()
+            .client_name(request.client_name)
+            .client_type("public")
+            .send()
             .await
             .map_err(|error| error.to_string())
             .and_then(TryInto::try_into)
@@ -45,7 +43,11 @@ impl Client {
 
         let start_device_authorization_response: StartDeviceAuthorizationResponse = self
             .inner
-            .start_device_authorization(request.into())
+            .start_device_authorization()
+            .client_id(request.client_id)
+            .client_secret(request.client_secret)
+            .start_url(request.start_url)
+            .send()
             .await
             .map_err(|error| error.to_string())
             .and_then(TryInto::try_into)
@@ -56,25 +58,25 @@ impl Client {
             .await
             .map_err(CreateTokenError::VerificationPrompt)?;
 
-        let create_token_request = rusoto_sso_oidc::CreateTokenRequest {
-            client_id,
-            client_secret,
-            code: Some(start_device_authorization_response.user_code),
-            device_code: start_device_authorization_response.device_code,
-            grant_type: "urn:ietf:params:oauth:grant-type:device_code".to_string(),
-            redirect_uri: None,
-            refresh_token: None,
-            scope: None,
-        };
+        let create_token_request = self
+            .inner
+            .create_token()
+            .client_id(client_id)
+            .client_secret(client_secret)
+            .code(start_device_authorization_response.user_code)
+            .device_code(start_device_authorization_response.device_code)
+            .grant_type("urn:ietf:params:oauth:grant-type:device_code".to_string());
         loop {
-            match self.inner.create_token(create_token_request.clone()).await {
+            match create_token_request.clone().send().await {
                 Ok(res) => break res.try_into().map_err(CreateTokenError::Api),
-                Err(RusotoError::Service(
-                    rusoto_sso_oidc::CreateTokenError::AuthorizationPending(_),
-                )) => {
+                Err(aws_sdk_ssooidc::types::SdkError::ServiceError { err, .. })
+                    if err.is_authorization_pending_exception() =>
+                {
                     tokio::time::sleep(start_device_authorization_response.interval).await;
                 }
-                Err(RusotoError::Service(rusoto_sso_oidc::CreateTokenError::ExpiredToken(_))) => {
+                Err(aws_sdk_ssooidc::types::SdkError::ServiceError { err, .. })
+                    if err.is_expired_token_exception() =>
+                {
                     return Err(CreateTokenError::VerificationPromptTimeout);
                 }
                 Err(error) => return Err(CreateTokenError::Api(error.to_string())),
@@ -94,16 +96,6 @@ pub(crate) struct RegisterClientRequest {
     pub(crate) client_name: String,
 }
 
-impl From<RegisterClientRequest> for rusoto_sso_oidc::RegisterClientRequest {
-    fn from(req: RegisterClientRequest) -> Self {
-        Self {
-            client_name: req.client_name,
-            client_type: "public".to_string(),
-            scopes: None,
-        }
-    }
-}
-
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub(crate) struct RegisterClientResponse {
     pub(crate) client_id: String,
@@ -117,10 +109,10 @@ impl cache::Expiry for RegisterClientResponse {
     }
 }
 
-impl TryFrom<rusoto_sso_oidc::RegisterClientResponse> for RegisterClientResponse {
+impl TryFrom<aws_sdk_ssooidc::output::RegisterClientOutput> for RegisterClientResponse {
     type Error = String;
 
-    fn try_from(res: rusoto_sso_oidc::RegisterClientResponse) -> Result<Self, Self::Error> {
+    fn try_from(res: aws_sdk_ssooidc::output::RegisterClientOutput) -> Result<Self, Self::Error> {
         macro_rules! invalid_res {
             ($msg:literal) => {
                 concat!("invalid RegisterClient response: ", $msg)
@@ -132,10 +124,7 @@ impl TryFrom<rusoto_sso_oidc::RegisterClientResponse> for RegisterClientResponse
             client_secret: res
                 .client_secret
                 .ok_or(invalid_res!("missing client_secret"))?,
-            client_secret_expires_at: res
-                .client_secret_expires_at
-                .map(|secs| Utc.timestamp(secs, 0))
-                .ok_or(invalid_res!("missing client_secret_expires_at"))?,
+            client_secret_expires_at: Utc.timestamp(res.client_secret_expires_at, 0),
         })
     }
 }
@@ -145,16 +134,6 @@ pub(crate) struct CreateTokenRequest {
     pub(crate) client_id: String,
     pub(crate) client_secret: String,
     pub(crate) start_url: String,
-}
-
-impl From<CreateTokenRequest> for rusoto_sso_oidc::StartDeviceAuthorizationRequest {
-    fn from(req: CreateTokenRequest) -> Self {
-        Self {
-            client_id: req.client_id,
-            client_secret: req.client_secret,
-            start_url: req.start_url,
-        }
-    }
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
@@ -169,10 +148,10 @@ impl cache::Expiry for CreateTokenResponse {
     }
 }
 
-impl TryFrom<rusoto_sso_oidc::CreateTokenResponse> for CreateTokenResponse {
+impl TryFrom<aws_sdk_ssooidc::output::CreateTokenOutput> for CreateTokenResponse {
     type Error = String;
 
-    fn try_from(res: rusoto_sso_oidc::CreateTokenResponse) -> Result<Self, Self::Error> {
+    fn try_from(res: aws_sdk_ssooidc::output::CreateTokenOutput) -> Result<Self, Self::Error> {
         macro_rules! invalid_res {
             ($msg:literal) => {
                 concat!("invalid CreateToken response: ", $msg)
@@ -183,10 +162,7 @@ impl TryFrom<rusoto_sso_oidc::CreateTokenResponse> for CreateTokenResponse {
             access_token: res
                 .access_token
                 .ok_or(invalid_res!("missing access_token"))?,
-            expires_at: Utc::now()
-                + chrono::Duration::seconds(
-                    res.expires_in.ok_or(invalid_res!("missing expires_in"))?,
-                ),
+            expires_at: Utc::now() + chrono::Duration::seconds(res.expires_in.into()),
         })
     }
 }
@@ -206,13 +182,13 @@ struct StartDeviceAuthorizationResponse {
     verification_uri_complete: Url,
 }
 
-impl TryFrom<rusoto_sso_oidc::StartDeviceAuthorizationResponse>
+impl TryFrom<aws_sdk_ssooidc::output::StartDeviceAuthorizationOutput>
     for StartDeviceAuthorizationResponse
 {
     type Error = String;
 
     fn try_from(
-        res: rusoto_sso_oidc::StartDeviceAuthorizationResponse,
+        res: aws_sdk_ssooidc::output::StartDeviceAuthorizationOutput,
     ) -> Result<Self, Self::Error> {
         macro_rules! invalid_res {
             ($msg:literal) => {
@@ -223,10 +199,7 @@ impl TryFrom<rusoto_sso_oidc::StartDeviceAuthorizationResponse>
         Ok(Self {
             device_code: res.device_code.ok_or(invalid_res!("missing device_code"))?,
             interval: std::time::Duration::from_secs(
-                res.interval
-                    .ok_or(invalid_res!("missing interval"))?
-                    .try_into()
-                    .expect("interval should fit u64"),
+                res.interval.try_into().expect("interval should fit u64"),
             ),
             user_code: res.user_code.ok_or(invalid_res!("missing user_code"))?,
             verification_uri_complete: res


### PR DESCRIPTION
- 314057f **doc: add an example of usage with the aws-sdk**

  Thos demonstrates that its possible to use the library as-is, and is
  also indicative of what would be needed for an in-tree integration.

- fefa25b **feat: add an `aws-sdk` feature enabling aws-sdk integration**

  This is analogous to the `rusoto` feature, with the same
  implementations:
  
  - aws-sdk's `ProvideCredentials` for `SsoFlowBuilder` and `SsoFlow`.
  - `From<SessionCredentials>` for aws-sdk's `Credentials`.
  
  `ProvideCredentials` requires implementors to also implement `Debug`,
  which required some crate types to implement `Debug`. Sadly this can't
  be derived for `SsoFlowBuilder` or `SsoFlow` since we want closures to
  be usable as verification prompts, and closures do not implement
  `Debug`.

- 1bf6c0a **fix: remove extraneous bound from rusoto impl for `SsoFlowBuilder`**


- e4fb286 **refactor!: use `aws-sdk` for AWS API calls**

  The crate no longer depends at all on rusoto, and instead uses aws-sdk
  to implement SSO and SSO OIDC API calls. This has lead to breaking
  changes in the `Region` API since aws-sdk's region does not implement
  `serde` traits or `FromStr` (in fact construction is infallible for
  arbitrary strings). Rather than trying to maintain the existing `Region`
  API it has been updated to refect aws-sdk's API. All other changes are
  internal-only.
  
  BREAKING CHANGE: `Region` no longer implements `serde::{Deserialize,
  Serialize}` or `FromStr`. `ParseRegionError` has been removed.

- a18b6fe **refactor: use `std::ready::Ready` for `SsoConfig::Future`**

  This removes a dependency (`futures`) from the public API.

- 9104272 **chore: bump version**


- e5a7403 **fix: pin `aws-types-integration` version in dev-dependencies**

  The `aws-types` version needs to match the `aws-config` version for the
  `aws-sdk` example to compile.
