### PR TITLE
Update aws-sdk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_sso_flow"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Chris Connelly <chris@connec.co.uk>"]
 license = "MIT"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-aws-config = { version = "0.49.0", default-features = false, features = ["client-hyper", "rt-tokio"] }
-aws-sdk-sso = { version = "0.19.0", default-features = false, features = ["rt-tokio"] }
-aws-sdk-ssooidc = { version = "0.19.0", default-features = false, features = ["rt-tokio"] }
+aws-config = { version = "0.55.3", default-features = false, features = ["client-hyper", "rt-tokio"] }
+aws-sdk-sso = { version = "0.28.0", default-features = false, features = ["rt-tokio"] }
+aws-sdk-ssooidc = { version = "0.28.0", default-features = false, features = ["rt-tokio"] }
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "serde"] }
 const-str = "0.4.3"
 dirs-next = "2.0.0"
@@ -51,8 +51,8 @@ rusoto_credential = { version = ">=0.43.0", optional = true }
 # bound so that the version can adapt to whatever clients are using. There will be breakage if the
 # trait changes in future, but that hopefully won't happen as often as new versions are released
 # with additional service coverage etc.
-aws-types-integration = { package = "aws-types", version = ">=0.31.0", optional = true }
+aws-types-integration = { package = "aws-credential-types", version = ">=0.31.0", optional = true }
 
 [dev-dependencies]
-aws-types-integration = { package = "aws-types", version = "=0.49.0" }
+aws-types-integration = { package = "aws-credential-types", version = "=0.55.3" }
 tokio = { version = "1.21.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/aws_sdk.rs
+++ b/examples/aws_sdk.rs
@@ -1,7 +1,7 @@
 use std::convert::Infallible;
 
 use aws_config::meta::credentials::CredentialsProviderChain;
-use aws_types_integration::credentials::ProvideCredentials;
+use aws_types_integration::provider::ProvideCredentials;
 
 use aws_sso_flow::SsoFlow;
 

--- a/src/aws_sdk.rs
+++ b/src/aws_sdk.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 
 use aws_types_integration::{
-    credentials::{
-        future::ProvideCredentials as ProvideCredentialsFut, CredentialsError, ProvideCredentials,
+    provider::{
+        error::CredentialsError, future::ProvideCredentials as ProvideCredentialsFut,
+        ProvideCredentials,
     },
     Credentials,
 };
@@ -102,7 +103,7 @@ where
 {
     fn provide_credentials<'a>(
         &'a self,
-    ) -> aws_types_integration::credentials::future::ProvideCredentials<'a>
+    ) -> aws_types_integration::provider::future::ProvideCredentials<'a>
     where
         Self: 'a,
     {

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -249,13 +249,11 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Api(error) => write!(f, "SSO authentication failed due to: {}", error),
-            Self::Cache(error) => write!(f, "SSO authentication failed due to: {}", error),
-            Self::VerificationPrompt(error) => write!(
-                f,
-                "SSO authentication failed during verification: {}",
-                error
-            ),
+            Self::Api(error) => write!(f, "SSO authentication failed due to: {error}"),
+            Self::Cache(error) => write!(f, "SSO authentication failed due to: {error}"),
+            Self::VerificationPrompt(error) => {
+                write!(f, "SSO authentication failed during verification: {error}",)
+            }
             Self::VerificationPromptTimeout => write!(
                 f,
                 "SSO authentication failed: timed out waiting for verification"

--- a/src/region.rs
+++ b/src/region.rs
@@ -5,7 +5,7 @@ use std::{borrow::Cow, fmt};
 // Use `Region` from `aws_sdk_sso` to avoid depending directly on `aws_types`. It's hoped this will
 // make it possible to integrate with other versions of aws-sdk than the one used to implement this
 // crate, since the `aws-types` dependency can be more flexible.
-use aws_sdk_sso::Region as SdkRegion;
+use aws_sdk_sso::config::Region as SdkRegion;
 
 /// An AWS region.
 #[derive(Clone, Eq, Hash, PartialEq)]

--- a/src/rusoto.rs
+++ b/src/rusoto.rs
@@ -3,10 +3,7 @@ use std::fmt;
 use async_trait::async_trait;
 use rusoto_credential::{AwsCredentials, CredentialsError, ProvideAwsCredentials};
 
-use crate::{
-    SessionCredentials, SsoConfigSource, SsoFlow, SsoFlowBuilder,
-    VerificationPrompt,
-};
+use crate::{SessionCredentials, SsoConfigSource, SsoFlow, SsoFlowBuilder, VerificationPrompt};
 
 #[async_trait]
 impl<S, V> ProvideAwsCredentials for SsoFlowBuilder<S, V>
@@ -123,7 +120,7 @@ impl ProvideAwsCredentials for ChainProvider {
             }
         }
 
-        let error_messages: Vec<_> = errors.iter().map(|error| format!("- {}", error)).collect();
+        let error_messages: Vec<_> = errors.iter().map(|error| format!("- {error}")).collect();
         Err(CredentialsError::new(format!(
             "Couldn't find AWS credentials through any configured provider; all errors:\n\n{}",
             error_messages.join("\n")


### PR DESCRIPTION
- b168bff **chore!: bump `aws-sdk` version requirement**

  BREAKING CHANGE: The various credentials types have moved into a
  different crate, so older versions of the AWS SDK are no longer
  compatible.

- 38fe23e **chore: fix clippy lints**


- 7024707 **chore: bump version**

