### PR TITLE
Bump aws-sdk dependencies to 1.0

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,9 +13,9 @@ jobs:
   update:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Cargo cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: ${{ github.sha }}
           path: |
@@ -34,9 +34,9 @@ jobs:
       matrix:
         aws-sdk: [true, false]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Cargo cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: ${{ github.sha }}
           path: |
@@ -46,7 +46,7 @@ jobs:
             ~/.cargo/registry/index
             Cargo.lock
       - name: Check cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: check-${{ matrix.aws-sdk }}-${{ hashFiles('Cargo.lock') }}
           path: target
@@ -63,9 +63,9 @@ jobs:
       matrix:
         aws-sdk: [true, false]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Cargo cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: ${{ github.sha }}
           path: |
@@ -75,7 +75,7 @@ jobs:
             ~/.cargo/registry/index
             Cargo.lock
       - name: Check cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: check-${{ matrix.aws-sdk }}-${{ hashFiles('Cargo.lock') }}
           path: target
@@ -92,9 +92,9 @@ jobs:
       matrix:
         aws-sdk: [true, false]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Cargo cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: ${{ github.sha }}
           path: |
@@ -104,7 +104,7 @@ jobs:
             ~/.cargo/registry/index
             Cargo.lock
       - name: Check cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: check-${{ matrix.aws-sdk }}-${{ hashFiles('Cargo.lock') }}
           path: target
@@ -121,9 +121,9 @@ jobs:
       matrix:
         aws-sdk: [true, false]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Cargo cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: ${{ github.sha }}
           path: |
@@ -133,7 +133,7 @@ jobs:
             ~/.cargo/registry/index
             Cargo.lock
       - name: Test cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           key: test-${{ matrix.aws-sdk }}-${{ hashFiles('Cargo.lock') }}
           path: target

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,7 +32,6 @@ jobs:
     needs: [update]
     strategy:
       matrix:
-        tls: [rustls, native]
         rusoto: [true, false]
         aws-sdk: [true, false]
     steps:
@@ -50,12 +49,12 @@ jobs:
       - name: Check cache
         uses: actions/cache@v2
         with:
-          key: check-${{ matrix.tls }}-${{ matrix.aws-sdk }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
+          key: check-${{ matrix.aws-sdk }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Check
         run: |
           cargo check --all-targets --no-default-features \
-            --features ${{ matrix.tls == 'rustls' && 'rustls' || 'native-tls' }} \
+            --features rustls \
             ${{ matrix.aws-sdk && '--features aws-sdk' || '' }} \
             ${{ matrix.rusoto && '--features rusoto' || '' }}
 
@@ -64,7 +63,6 @@ jobs:
     needs: [check]
     strategy:
       matrix:
-        tls: [rustls, native]
         rusoto: [true, false]
     steps:
       - uses: actions/checkout@v2
@@ -81,12 +79,12 @@ jobs:
       - name: Check cache
         uses: actions/cache@v2
         with:
-          key: check-${{ matrix.tls }}-${{ matrix.aws-sdk }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
+          key: check-${{ matrix.aws-sdk }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Clippy
         run: |
           cargo clippy --all-targets --no-default-features \
-            --features ${{ matrix.tls == 'rustls' && 'rustls' || 'native-tls' }} \
+            --features rustls \
             ${{ matrix.aws-sdk && '--features aws-sdk' || '' }} \
             ${{ matrix.rusoto && '--features rusoto' || '' }}
 
@@ -95,7 +93,6 @@ jobs:
     needs: [check]
     strategy:
       matrix:
-        tls: [rustls, native]
         rusoto: [true, false]
     steps:
       - uses: actions/checkout@v2
@@ -112,12 +109,12 @@ jobs:
       - name: Check cache
         uses: actions/cache@v2
         with:
-          key: check-${{ matrix.tls }}-${{ matrix.aws-sdk }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
+          key: check-${{ matrix.aws-sdk }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Doc check
         run: |
           cargo doc --no-deps --no-default-features \
-            --features ${{ matrix.tls == 'rustls' && 'rustls' || 'native-tls' }} \
+            --features rustls \
             ${{ matrix.aws-sdk && '--features aws-sdk' || '' }} \
             ${{ matrix.rusoto && '--features rusoto' || '' }}
 
@@ -126,7 +123,6 @@ jobs:
     needs: [update]
     strategy:
       matrix:
-        tls: [rustls, native]
         rusoto: [true, false]
     steps:
       - uses: actions/checkout@v2
@@ -143,12 +139,12 @@ jobs:
       - name: Test cache
         uses: actions/cache@v2
         with:
-          key: test-${{ matrix.tls }}-${{ matrix.aws-sdk }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
+          key: test-${{ matrix.aws-sdk }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Test
         run: |
           cargo test --no-default-features \
-            --features ${{ matrix.tls == 'rustls' && 'rustls' || 'native-tls' }} \
+            --features rustls \
             ${{ matrix.aws-sdk && '--features aws-sdk' || '' }} \
             ${{ matrix.rusoto && '--features rusoto' || '' }}
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,7 +32,6 @@ jobs:
     needs: [update]
     strategy:
       matrix:
-        rusoto: [true, false]
         aws-sdk: [true, false]
     steps:
       - uses: actions/checkout@v2
@@ -49,21 +48,20 @@ jobs:
       - name: Check cache
         uses: actions/cache@v2
         with:
-          key: check-${{ matrix.aws-sdk }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
+          key: check-${{ matrix.aws-sdk }}-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Check
         run: |
           cargo check --all-targets --no-default-features \
             --features rustls \
-            ${{ matrix.aws-sdk && '--features aws-sdk' || '' }} \
-            ${{ matrix.rusoto && '--features rusoto' || '' }}
+            ${{ matrix.aws-sdk && '--features aws-sdk' || '' }}
 
   clippy:
     runs-on: ubuntu-20.04
     needs: [check]
     strategy:
       matrix:
-        rusoto: [true, false]
+        aws-sdk: [true, false]
     steps:
       - uses: actions/checkout@v2
       - name: Cargo cache
@@ -79,21 +77,20 @@ jobs:
       - name: Check cache
         uses: actions/cache@v2
         with:
-          key: check-${{ matrix.aws-sdk }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
+          key: check-${{ matrix.aws-sdk }}-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Clippy
         run: |
           cargo clippy --all-targets --no-default-features \
             --features rustls \
-            ${{ matrix.aws-sdk && '--features aws-sdk' || '' }} \
-            ${{ matrix.rusoto && '--features rusoto' || '' }}
+            ${{ matrix.aws-sdk && '--features aws-sdk' || '' }}
 
   doc-check:
     runs-on: ubuntu-20.04
     needs: [check]
     strategy:
       matrix:
-        rusoto: [true, false]
+        aws-sdk: [true, false]
     steps:
       - uses: actions/checkout@v2
       - name: Cargo cache
@@ -109,21 +106,20 @@ jobs:
       - name: Check cache
         uses: actions/cache@v2
         with:
-          key: check-${{ matrix.aws-sdk }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
+          key: check-${{ matrix.aws-sdk }}-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Doc check
         run: |
           cargo doc --no-deps --no-default-features \
             --features rustls \
-            ${{ matrix.aws-sdk && '--features aws-sdk' || '' }} \
-            ${{ matrix.rusoto && '--features rusoto' || '' }}
+            ${{ matrix.aws-sdk && '--features aws-sdk' || '' }}
 
   test:
     runs-on: ubuntu-20.04
     needs: [update]
     strategy:
       matrix:
-        rusoto: [true, false]
+        aws-sdk: [true, false]
     steps:
       - uses: actions/checkout@v2
       - name: Cargo cache
@@ -139,14 +135,13 @@ jobs:
       - name: Test cache
         uses: actions/cache@v2
         with:
-          key: test-${{ matrix.aws-sdk }}-${{ matrix.rusoto }}-${{ hashFiles('Cargo.lock') }}
+          key: test-${{ matrix.aws-sdk }}-${{ hashFiles('Cargo.lock') }}
           path: target
       - name: Test
         run: |
           cargo test --no-default-features \
             --features rustls \
-            ${{ matrix.aws-sdk && '--features aws-sdk' || '' }} \
-            ${{ matrix.rusoto && '--features rusoto' || '' }}
+            ${{ matrix.aws-sdk && '--features aws-sdk' || '' }}
 
   status:
     runs-on: ubuntu-20.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ required-features = ["aws-sdk"]
 
 [features]
 default = ["rustls"]
-native-tls = ["aws-config/native-tls", "aws-sdk-sso/native-tls", "aws-sdk-ssooidc/native-tls"]
 rustls = ["aws-config/rustls", "aws-sdk-sso/rustls", "aws-sdk-ssooidc/rustls"]
 
 # Include integration with aws-sdk
@@ -27,9 +26,9 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-aws-config = { version = "0.55.3", default-features = false, features = ["client-hyper", "rt-tokio"] }
-aws-sdk-sso = { version = "0.28.0", default-features = false, features = ["rt-tokio"] }
-aws-sdk-ssooidc = { version = "0.28.0", default-features = false, features = ["rt-tokio"] }
+aws-config = { version = "1", default-features = false, features = ["client-hyper", "rt-tokio"] }
+aws-sdk-sso = { version = "1", default-features = false, features = ["rt-tokio"] }
+aws-sdk-ssooidc = { version = "1", default-features = false, features = ["rt-tokio"] }
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "serde"] }
 const-str = "0.4.3"
 dirs-next = "2.0.0"
@@ -51,8 +50,9 @@ rusoto_credential = { version = ">=0.43.0", optional = true }
 # bound so that the version can adapt to whatever clients are using. There will be breakage if the
 # trait changes in future, but that hopefully won't happen as often as new versions are released
 # with additional service coverage etc.
-aws-types-integration = { package = "aws-credential-types", version = ">=0.31.0", optional = true }
+aws-types-integration = { package = "aws-credential-types", version = "1", optional = true }
 
 [dev-dependencies]
-aws-types-integration = { package = "aws-credential-types", version = "=0.55.3" }
+aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "client-hyper", "rt-tokio"] }
+aws-types-integration = { package = "aws-credential-types", version = "1" }
 tokio = { version = "1.21.0", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,6 @@ rustls = ["aws-config/rustls", "aws-sdk-sso/rustls", "aws-sdk-ssooidc/rustls"]
 # Include integration with aws-sdk
 aws-sdk = ["dep:aws-types-integration"]
 
-# Include integration with rusoto_credential
-rusoto = ["async-trait", "rusoto_credential"]
-
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
@@ -40,11 +37,6 @@ tokio = { version = "1.21.0", features = ["fs", "io-util", "sync"] }
 url = "2.3.1"
 
 async-trait = { version = "0.1.57", optional = true }
-# The version constraint is the lowest with a compatible ProvideAwsCredentials trait. There's no
-# upper bound so that the version can adapt to whatever clients are using. There will be breakage if
-# if the trait changes in future, but that hopefully won't happen as often as new versions are
-# released with additional service coverage etc.
-rusoto_credential = { version = ">=0.43.0", optional = true }
 
 # The version constraint is the lowest with a compatible ProvideCredentials trait. There's no upper
 # bound so that the version can adapt to whatever clients are using. There will be breakage if the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_sso_flow"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Chris Connelly <chris@connec.co.uk>"]
 license = "MIT"
 edition = "2021"

--- a/src/aws_sdk.rs
+++ b/src/aws_sdk.rs
@@ -24,11 +24,11 @@ use crate::{SessionCredentials, SsoConfigSource, SsoFlow, SsoFlowBuilder, Verifi
 ///
 /// ```no_run
 /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// # use aws_types_integration as aws_types;
+/// # use aws_types_integration as aws_credential_types;
 /// use std::convert::Infallible;
 ///
 /// use aws_config::meta::credentials::CredentialsProviderChain;
-/// use aws_types::credentials::ProvideCredentials;
+/// use aws_credential_types::provider::ProvideCredentials;
 /// use aws_sso_flow::{Region, SsoConfig, SsoFlow};
 ///
 /// // Configure an SSO flow that loads SSO from shared config and prints the verification URL

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -149,6 +149,7 @@ where
     /// # Errors
     ///
     /// Returns any errors encountered when loading the [`SsoConfigSource`].
+    #[allow(clippy::missing_panics_doc)]
     pub async fn build(self) -> Result<SsoFlow<V>, S::Error> {
         let config = self.config_source.load().await?;
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -71,7 +71,7 @@ impl Cache {
             let content =
                 serde_json::to_string_pretty(&value).expect("tried to cache unserializable value");
             fs::create_dir_all(path.parent().expect("path in dir"))
-                .and_then(|_| fs::write(path, &content))
+                .and_then(|()| fs::write(path, &content))
                 .await
                 .map_err(|error| Error::cache("failed to write", path, error))?;
         }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -28,7 +28,7 @@ impl fmt::Debug for SessionCredentials {
         f.debug_struct("SessionCredentials")
             .field("access_key_id", &self.access_key_id)
             .field("expires_at", &self.expires_at)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -1,6 +1,6 @@
 use std::{convert::Infallible, fmt, path::PathBuf};
 
-use aws_config::SdkConfig;
+use aws_config::{BehaviorVersion, SdkConfig};
 use url::Url;
 
 use crate::{
@@ -81,7 +81,10 @@ where
         config: SsoConfig,
         verification_prompt: V,
     ) -> Self {
-        let sdk_config = SdkConfig::builder().region(config.region.0.clone()).build();
+        let sdk_config = SdkConfig::builder()
+            .behavior_version(BehaviorVersion::latest())
+            .region(config.region.0.clone())
+            .build();
 
         Self {
             cache: Cache::new(cache_dir, &config),

--- a/src/sso_oidc.rs
+++ b/src/sso_oidc.rs
@@ -97,6 +97,7 @@ pub(crate) struct RegisterClientRequest {
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[allow(clippy::struct_field_names)]
 pub(crate) struct RegisterClientResponse {
     pub(crate) client_id: String,
     pub(crate) client_secret: String,
@@ -123,7 +124,9 @@ impl TryFrom<aws_sdk_ssooidc::operation::register_client::RegisterClientOutput>
             };
         }
 
-        let chrono::LocalResult::Single(client_secret_expires_at) = Utc.timestamp_opt(res.client_secret_expires_at, 0) else {
+        let chrono::LocalResult::Single(client_secret_expires_at) =
+            Utc.timestamp_opt(res.client_secret_expires_at, 0)
+        else {
             panic!("invalid client_secret_expires_at");
         };
         Ok(Self {


### PR DESCRIPTION
- 48d612d **chore!: bump aws-sdk dependencies to 1.0**

  This also removes the `native-tls` feature as native TLS is no longer
  supported by the AWS SDK.
  
  BREAKING CHANGE: This now must be used with `aws-sdk>=1`.

- fe8b972 **chore!: remove `rusoto` feature**

  rusoto is in maintenance mode and is essentially superseded by the
  official `aws-sdk`.
  
  BREAKING CHANGE: The library no longer supports `rusoto`.

- 90ecb50 **chore: fix lints**


- 2c9981c **chore: bump version**


- df7cfbb **chore: bump github action versions**

